### PR TITLE
4.rc.1 error: make buffer length match unpacked

### DIFF
--- a/adafruit_focaltouch.py
+++ b/adafruit_focaltouch.py
@@ -87,7 +87,7 @@ class Adafruit_FocalTouch:
         self._i2c = I2CDevice(i2c, address)
         self._debug = debug
 
-        chip_data = self._read(_FT6XXX_REG_LIBH, 9)
+        chip_data = self._read(_FT6XXX_REG_LIBH, 8)
         lib_ver, chip_id, _, _, firm_id, _, vend_id = struct.unpack('>HBBBBBB', chip_data)
 
         if vend_id != 0x11:


### PR DESCRIPTION
Issue: when running this on 4.rc.1 it was unable to load properly on instantiation due to the length of the "chip_data" buffer being one too long.

the length of '>HBBBBBB' is now equal to the length of chip_data.