### PR TITLE
Add option for IRQ pin to wait for _read

### DIFF
--- a/adafruit_focaltouch.py
+++ b/adafruit_focaltouch.py
@@ -67,11 +67,12 @@ class Adafruit_FocalTouch:
     _debug = False
     chip = None
 
-    def __init__(self, i2c, address=_FT6206_DEFAULT_I2C_ADDR, debug=False):
+    def __init__(self, i2c, address=_FT6206_DEFAULT_I2C_ADDR, debug=False, irq_pin=None):
         self._i2c = I2CDevice(i2c, address)
         self._debug = debug
+        self.irq_pin = irq_pin
 
-        chip_data = self._read(_FT6XXX_REG_LIBH, 8)
+        chip_data = self._read(_FT6XXX_REG_LIBH, 8) # don't wait for IRQ
         lib_ver, chip_id, _, _, firm_id, _, vend_id = struct.unpack(
             ">HBBBBBB", chip_data
         )
@@ -90,10 +91,11 @@ class Adafruit_FocalTouch:
             print("Point rate %d Hz" % self._read(_FT6XXX_REG_POINTRATE, 1)[0])
             print("Thresh %d" % self._read(_FT6XXX_REG_THRESHHOLD, 1)[0])
 
+
     @property
     def touched(self):
         """ Returns the number of touches currently detected """
-        return self._read(_FT6XXX_REG_NUMTOUCHES, 1)[0]
+        return self._read(_FT6XXX_REG_NUMTOUCHES, 1, irq_pin=self.irq_pin)[0]
 
     # pylint: disable=unused-variable
     @property
@@ -103,7 +105,7 @@ class Adafruit_FocalTouch:
         touch coordinates, and 'id' as the touch # for multitouch tracking
         """
         touchpoints = []
-        data = self._read(_FT6XXX_REG_DATA, 32)
+        data = self._read(_FT6XXX_REG_DATA, 32, irq_pin=self.irq_pin)
 
         for i in range(2):
             point_data = data[i * 6 + 3 : i * 6 + 9]
@@ -121,11 +123,17 @@ class Adafruit_FocalTouch:
 
     # pylint: enable=unused-variable
 
-    def _read(self, register, length):
+    def _read(self, register, length, irq_pin=None):
         """Returns an array of 'length' bytes from the 'register'"""
         with self._i2c as i2c:
+
+            if (irq_pin is not None):
+                while (self.irq_pin.value):
+                    pass
+
             i2c.write(bytes([register & 0xFF]))
             result = bytearray(length)
+
             i2c.readinto(result)
             if self._debug:
                 print("\t$%02X => %s" % (register, [hex(i) for i in result]))

--- a/adafruit_focaltouch.py
+++ b/adafruit_focaltouch.py
@@ -129,7 +129,7 @@ class Adafruit_FocalTouch:
         with self._i2c as i2c:
 
             if irq_pin is not None:
-                while self._irq_pin.value:
+                while irq_pin.value:
                     pass
 
             i2c.write(bytes([register & 0xFF]))

--- a/adafruit_focaltouch.py
+++ b/adafruit_focaltouch.py
@@ -72,7 +72,7 @@ class Adafruit_FocalTouch:
     ):
         self._i2c = I2CDevice(i2c, address)
         self._debug = debug
-        self.irq_pin = irq_pin
+        self._irq_pin = irq_pin
 
         chip_data = self._read(_FT6XXX_REG_LIBH, 8)  # don't wait for IRQ
         lib_ver, chip_id, _, _, firm_id, _, vend_id = struct.unpack(
@@ -96,7 +96,7 @@ class Adafruit_FocalTouch:
     @property
     def touched(self):
         """ Returns the number of touches currently detected """
-        return self._read(_FT6XXX_REG_NUMTOUCHES, 1, irq_pin=self.irq_pin)[0]
+        return self._read(_FT6XXX_REG_NUMTOUCHES, 1, irq_pin=self._irq_pin)[0]
 
     # pylint: disable=unused-variable
     @property
@@ -106,7 +106,7 @@ class Adafruit_FocalTouch:
         touch coordinates, and 'id' as the touch # for multitouch tracking
         """
         touchpoints = []
-        data = self._read(_FT6XXX_REG_DATA, 32, irq_pin=self.irq_pin)
+        data = self._read(_FT6XXX_REG_DATA, 32, irq_pin=self._irq_pin)
 
         for i in range(2):
             point_data = data[i * 6 + 3 : i * 6 + 9]
@@ -129,7 +129,7 @@ class Adafruit_FocalTouch:
         with self._i2c as i2c:
 
             if irq_pin is not None:
-                while self.irq_pin.value:
+                while self._irq_pin.value:
                     pass
 
             i2c.write(bytes([register & 0xFF]))

--- a/adafruit_focaltouch.py
+++ b/adafruit_focaltouch.py
@@ -67,12 +67,14 @@ class Adafruit_FocalTouch:
     _debug = False
     chip = None
 
-    def __init__(self, i2c, address=_FT6206_DEFAULT_I2C_ADDR, debug=False, irq_pin=None):
+    def __init__(
+        self, i2c, address=_FT6206_DEFAULT_I2C_ADDR, debug=False, irq_pin=None
+    ):
         self._i2c = I2CDevice(i2c, address)
         self._debug = debug
         self.irq_pin = irq_pin
 
-        chip_data = self._read(_FT6XXX_REG_LIBH, 8) # don't wait for IRQ
+        chip_data = self._read(_FT6XXX_REG_LIBH, 8)  # don't wait for IRQ
         lib_ver, chip_id, _, _, firm_id, _, vend_id = struct.unpack(
             ">HBBBBBB", chip_data
         )
@@ -90,7 +92,6 @@ class Adafruit_FocalTouch:
             print("Firmware ID %02X" % firm_id)
             print("Point rate %d Hz" % self._read(_FT6XXX_REG_POINTRATE, 1)[0])
             print("Thresh %d" % self._read(_FT6XXX_REG_THRESHHOLD, 1)[0])
-
 
     @property
     def touched(self):
@@ -127,8 +128,8 @@ class Adafruit_FocalTouch:
         """Returns an array of 'length' bytes from the 'register'"""
         with self._i2c as i2c:
 
-            if (irq_pin is not None):
-                while (self.irq_pin.value):
+            if irq_pin is not None:
+                while self.irq_pin.value:
                     pass
 
             i2c.write(bytes([register & 0xFF]))

--- a/examples/focaltouch_print_touches_with_irq.py
+++ b/examples/focaltouch_print_touches_with_irq.py
@@ -1,0 +1,47 @@
+# SPDX-FileCopyrightText: 2021 ladyada for Adafruit Industries
+# SPDX-License-Identifier: MIT
+
+"""
+Example for getting touch data from an FT6206 or FT6236 capacitive
+touch driver, over I2C.  This version uses an interrupt to prevent
+read errors from the FocalTouch chip.
+"""
+
+import time
+import busio
+import board
+from digitalio import DigitalInOut, Direction
+import adafruit_focaltouch
+
+
+if hasattr(
+    board, "SCL"
+):  # if SCL and SDA pins are defined by the board definition, use them.
+    SCL_pin = board.SCL
+    SDA_pin = board.SDA
+else:
+    SCL_pin = board.IO42  # set to a pin that you want to use for SCL
+    SDA_pin = board.IO41  # set to a pin that you want to use for SDA
+
+IRQ_pin = board.IO39  # select a pin to connect to the display's interrupt pin ("IRQ")
+
+i2c = busio.I2C(SCL_pin, SDA_pin)
+
+# Setup the interrupt (IRQ) pin for input
+irq = DigitalInOut(board.IO39)
+irq.direction = Direction.INPUT
+
+# Create library object (named "ft") using a Bus I2C port and using an interrupt pin (IRQ)
+ft = adafruit_focaltouch.Adafruit_FocalTouch(i2c, debug=False, irq_pin=irq)
+
+
+print("\n\nReady for touches...")
+
+while True:
+    # if the screen is being touched print the touches
+    if ft.touched:
+        print(ft.touches)
+    else:
+        print("no touch")
+
+    time.sleep(0.05)


### PR DESCRIPTION
This is to help resolve crashes during writes/reads, from [issue](https://github.com/adafruit/Adafruit_CircuitPython_FocalTouch/issues/9).


I added a connection to the IRQ pin of the ([TFT display breakout](https://www.adafruit.com/product/1947)) and polling it before the write cycle, and that seems to resolve the issue.

Here's the updated setup in my `code.py` file:
```python
print("Setting up I2C...")

i2c = busio.I2C(board.IO42, board.IO41)
irq = DigitalInOut(board.IO39)
irq.direction = Direction.INPUT
ft = adafruit_focaltouch.Adafruit_FocalTouch(i2c, debug=False, irq_pin = irq)
```

Here's my code change to the [FocalTouch library](https://github.com/adafruit/Adafruit_CircuitPython_FocalTouch/blob/master/adafruit_focaltouch.py).  I add an `irq_pin` in the initialization.  Then in the `_read` I wait for the `irq_pin` to go low before sending the write command.

**One issue**:  I had to eliminate the need to check for IRQ during initialization, because the display would hang in the `Adafruit_FocalTouch.__init__` function while waiting for a touch interrupt.  So, I ignore the interrupt in the `init` function, but require it for all other reads.
