### PR TITLE
Add vendor ID 0x20 to FT chip check

### DIFF
--- a/adafruit_focaltouch.py
+++ b/adafruit_focaltouch.py
@@ -86,7 +86,7 @@ class Adafruit_FocalTouch:
                 f"lib_ver: {lib_ver:02X}, chip_id: {chip_id:02X}, firm_id: {firm_id:02X}, vend_id: {vend_id:02X}"  # noqa: E501
             )
 
-        if vend_id not in {0x11, 0x42, 0x01, 0x02,0x20}:
+        if vend_id not in {0x11, 0x42, 0x01, 0x02, 0x20}:
             raise RuntimeError("Did not find FT chip")
 
         if chip_id == 0x06:

--- a/adafruit_focaltouch.py
+++ b/adafruit_focaltouch.py
@@ -86,7 +86,7 @@ class Adafruit_FocalTouch:
                 f"lib_ver: {lib_ver:02X}, chip_id: {chip_id:02X}, firm_id: {firm_id:02X}, vend_id: {vend_id:02X}"  # noqa: E501
             )
 
-        if vend_id not in {0x11, 0x42, 0x01, 0x02}:
+        if vend_id not in {0x11, 0x42, 0x01, 0x02,0x20}:
             raise RuntimeError("Did not find FT chip")
 
         if chip_id == 0x06:


### PR DESCRIPTION
I got the error "raise RuntimeError("Did not find FT chip")" On my CoreS3 SE
Did some checks, turned out my touchscreen has the vend_id 0x20. So I added this id to the code and now it works.